### PR TITLE
tw26923219 - updates module requirements and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/wanzer.info.yml
+++ b/wanzer.info.yml
@@ -5,8 +5,6 @@ package: UCSF
 core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
-  - allowed_formats:allowed_formats
-  - drupal:datetime
   - drupal:path
   - drupal:text
   - drupal:user
@@ -15,4 +13,5 @@ dependencies:
   - media_library:media_library
   - media_library_edit:media_library_edit
   - paragraphs:paragraphs
+  - smart_date:smart_date
   - title_field_for_manage_display:title_field_for_manage_display


### PR DESCRIPTION
### Teamwork Task
https://kanopi.teamwork.com/#/tasks/26923219

### What we're doing
Updating the module's requirements and the gitignore file.

### Where we're doing it
wanzer.info and .gitignore

### How we'll test it

1. Clone [Kanilla](https://github.com/kanopi/kanilla) project
2. Run `fin init` (this will spin up local and get the main branch of the wanzer module)
3. Cd into web/modules/custom
4. Run `rm -rf wanzer`
5. Run `git clone git@github.com:kanopi/wanzer.git wanzer`
6. Cd into wanzer
7. Checkout this branch `git checkout tw26923219-requirements`
8. Run `fin drush en -y wanzer`
9. Validate no errors are encountered (module doesn't actually do anything yet)

### Helpful links and documents
[Kanilla](https://github.com/kanopi/kanilla)
[Wanzer](https://github.com/kanopi/wanzer)
